### PR TITLE
Python3 docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 11yr_stochastic_analysis
+# 11yr Stochastic Analysis
 
 * Pull the latest docker image:
 ```
@@ -11,7 +11,8 @@ This will ensure that any data products are persistent, even if you delete the d
 ```
 docker run -it -p 8888:8888 \
  -v /path/to/local/dir/:/home/nanograv/local_data/ \
- -u nanograv nanograv/nano11y-gwb run_jupyter.sh
+ -u nanograv nanograv/nano11y-gwb
 ```
+the default action for `docker run` will launch a jupyter notebook in the container home directory.
 
 * Copy and paste the output URL into your browser.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -50,7 +50,7 @@ RUN wget -q https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.s
     bash Miniconda3-latest-Linux-x86_64.sh -b -p /home/nanograv/.local/miniconda && \
     rm Miniconda3-latest-Linux-x86_64.sh
 
-ENV PATH="/home/nanograv/.local/miniconda/bin:/home/nanograv/bin:${PATH}"
+ENV PATH="/home/nanograv/.local/miniconda/bin:/home/nanograv/.local/bin:${PATH}"
 
 # install basic Python packages
 RUN conda install -y numpy cython scipy && \
@@ -69,9 +69,6 @@ ENV MKL_NUM_THREADS=4
 # Jupyter notebook extensions
 RUN pip install jupyter_contrib_nbextensions && \
     jupyter contrib nbextension install --user
-
-# Jupyter notebook access script
-COPY run_jupyter.sh /home/nanograv/.local/bin
 
 # non-standard-Anaconda packages
 RUN pip install healpy acor line_profiler jplephem corner numdifftools
@@ -104,3 +101,6 @@ COPY matplotlibrc /home/nanograv/.config/matplotlib
 RUN wget -q https://data.nanograv.org/static/data/NANOGrav_11y_20171023.tgz && \
     tar -xzf NANOGrav_11y_20171023.tgz && \
     rm NANOGrav_11y_20171023.tgz
+
+# default entry command:
+CMD jupyter notebook --no-browser --port 8888 --ip=0.0.0.0

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,9 +3,10 @@ WORKDIR /root/install
 
 RUN useradd -ms /bin/bash nanograv
 
-# install LAPACK
+# install LAPACK & SuiteSparse
 RUN apt-get -y update && \
     apt-get -y install liblapack3 && \
+    apt-get -y install libsuitesparse-dev && \
     apt-get clean
 
 # install a few other basic tools
@@ -13,7 +14,6 @@ RUN apt-get -y install less gawk vim && \
     apt-get clean
 
 # make calceph
-#RUN wget -q http://www.imcce.fr/fr/presentation/equipes/ASD/inpop/calceph/calceph-2.3.2.tar.gz && \
 RUN wget -q https://www.imcce.fr/content/medias/recherche/equipes/asd/calceph/calceph-2.3.2.tar.gz && \
     tar zxvf calceph-2.3.2.tar.gz && \
     cd calceph-2.3.2 && \
@@ -80,11 +80,8 @@ COPY run_jupyter.sh /home/nanograv/bin
 # non-standard-Anaconda packages
 RUN pip install healpy acor line_profiler jplephem corner numdifftools
 
-# install scikit-sparse last (in case it messes with MKL, but it may be possible to move it earlier)
-# menpo uses v3 of SuiteSparse, consider building from source in future
-# http://faculty.cse.tamu.edu/davis/SuiteSparse/SuiteSparse-5.1.0.tar.gz
-RUN conda install -y -c menpo scikit-sparse && \
-    conda clean -a
+#install scikit-sparse (use apt-get for SuiteSparse)
+RUN pip install scikit-sparse
 
 # install PTMCMCSampler
 RUN git clone https://github.com/jellis18/PTMCMCSampler && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -76,6 +76,17 @@ COPY run_jupyter.sh /home/nanograv/bin
 # non-standard-Anaconda packages
 RUN pip install healpy acor line_profiler jplephem corner numdifftools
 
+# can't find proper way to link MKL '-lmkl_rt' works on local Mac...
+# manually build SuiteSparse against Intel MKL
+#RUN wget -q http://faculty.cse.tamu.edu/davis/SuiteSparse/SuiteSparse-5.1.0.tar.gz && \
+#    tar -xzf SuiteSparse-5.1.0.tar.gz
+# && \
+#RUN cd SuiteSparse && \
+#    make library INSTALL=/usr/local \
+#      BLAS="-L/home/nanograv/.local/miniconda/lib -lmkl_rt" \
+#      LAPACK="-L/home/nanograv/.local/miniconda/lib -lmkl_rt" && \
+#    cd .. && rm -rf SuiteSparse/ SuiteSparse-5.1.0.tar.gz
+
 #install scikit-sparse (use apt-get for SuiteSparse)
 RUN pip install scikit-sparse
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -72,7 +72,7 @@ RUN pip install jupyter_contrib_nbextensions && \
     jupyter contrib nbextension install --user
 
 # non-standard-Anaconda packages
-RUN pip install healpy acor line_profiler jplephem corner numdifftools
+RUN pip install healpy line_profiler jplephem corner numdifftools
 
 # can't find proper way to link MKL '-lmkl_rt' works on local Mac...
 # manually build SuiteSparse against Intel MKL
@@ -88,7 +88,8 @@ RUN pip install healpy acor line_profiler jplephem corner numdifftools
 #install scikit-sparse (use apt-get for SuiteSparse)
 RUN pip install scikit-sparse
 
-# install PTMCMCSampler
+# install PTMCMCSampler (and py3 compatible acor)
+RUN pip install git+https://github.com/dfm/acor.git@master
 RUN pip install git+https://github.com/jellis18/PTMCMCSampler@master
 
 # install enterprise (11 Dec 2017)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -84,15 +84,10 @@ RUN pip install healpy acor line_profiler jplephem corner numdifftools
 RUN pip install scikit-sparse
 
 # install PTMCMCSampler
-RUN git clone https://github.com/jellis18/PTMCMCSampler && \
-    cd PTMCMCSampler && \
-    python setup.py install
+RUN pip install git+https://github.com/jellis18/PTMCMCSampler@master
 
 # install enterprise (11 Dec 2017)
-RUN git clone https://github.com/nanograv/enterprise && \
-    cd enterprise && \
-    git reset --hard 04607ef && \
-    python setup.py install
+RUN pip install git+https://github.com/nanograv/enterprise@04607ef
 
 # matplotlib rc (default backend: Agg)
 RUN mkdir -p /home/nanograv/.config/matplotlib

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -71,7 +71,7 @@ RUN pip install jupyter_contrib_nbextensions && \
     jupyter contrib nbextension install --user
 
 # Jupyter notebook access script
-COPY run_jupyter.sh /home/nanograv/bin
+COPY run_jupyter.sh /home/nanograv/.local/bin
 
 # non-standard-Anaconda packages
 RUN pip install healpy acor line_profiler jplephem corner numdifftools

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -34,7 +34,10 @@ RUN git clone https://bitbucket.org/psrsoft/tempo2 && \
     ./configure --prefix=/home/nanograv/.local --with-calceph=/usr/local && \
     make && make install && \
     mkdir -p /home/nanograv/.local/share/tempo2 && \
-    cp -Rp T2runtime/* /home/nanograv/.local/share/tempo2/.
+    cp -Rp T2runtime/* /home/nanograv/.local/share/tempo2/. && \
+    cd .. && rm -rf tempo2
+
+ENV TEMPO2=/home/nanograv/.local/share/tempo2
 
 # get extra ephemeris
 RUN cd /home/nanograv/.local/share/tempo2/ephemeris && \
@@ -42,8 +45,6 @@ RUN cd /home/nanograv/.local/share/tempo2/ephemeris && \
     wget -q ftp://ssd.jpl.nasa.gov/pub/eph/planets/bsp/de436t.bsp && \
     wget -q https://github.com/nanograv/tempo/raw/master/ephem/DE435.1950.2050 && \
     wget -q https://github.com/nanograv/tempo/raw/master/ephem/DE436.1950.2050
-
-ENV TEMPO2=/home/nanograv/.local/share/tempo2
 
 # install miniconda
 RUN wget -q https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,8 +22,8 @@ RUN wget -q https://www.imcce.fr/content/medias/recherche/equipes/asd/calceph/ca
     cd .. && rm -rf calceph-2.3.2 calceph-2.3.2.tar.gz
 
 USER nanograv
-RUN mkdir /home/nanograv/source
-WORKDIR /home/nanograv/source
+RUN mkdir /home/nanograv/.local
+WORKDIR /home/nanograv
 
 ENV LD_LIBRARY_PATH="/usr/local/lib"
 
@@ -31,26 +31,26 @@ ENV LD_LIBRARY_PATH="/usr/local/lib"
 RUN git clone https://bitbucket.org/psrsoft/tempo2 && \
     cd tempo2 && \
     ./bootstrap && \
-    ./configure --prefix=/home/nanograv --with-calceph=/usr/local && \
+    ./configure --prefix=/home/nanograv/.local --with-calceph=/usr/local && \
     make && make install && \
-    mkdir -p /home/nanograv/share/tempo2 && \
-    cp -Rp T2runtime/* /home/nanograv/share/tempo2/.
+    mkdir -p /home/nanograv/.local/share/tempo2 && \
+    cp -Rp T2runtime/* /home/nanograv/.local/share/tempo2/.
 
 # get extra ephemeris
-RUN cd /home/nanograv/share/tempo2/ephemeris && \
+RUN cd /home/nanograv/.local/share/tempo2/ephemeris && \
     wget -q ftp://ssd.jpl.nasa.gov/pub/eph/planets/bsp/de435t.bsp && \
     wget -q ftp://ssd.jpl.nasa.gov/pub/eph/planets/bsp/de436t.bsp && \
     wget -q https://github.com/nanograv/tempo/raw/master/ephem/DE435.1950.2050 && \
     wget -q https://github.com/nanograv/tempo/raw/master/ephem/DE436.1950.2050
 
-ENV TEMPO2=/home/nanograv/share/tempo2
+ENV TEMPO2=/home/nanograv/.local/share/tempo2
 
 # install miniconda
-RUN wget -q https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh && \
-    bash Miniconda2-latest-Linux-x86_64.sh -b -p /home/nanograv/miniconda2 && \
-    rm Miniconda2-latest-Linux-x86_64.sh
+RUN wget -q https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
+    bash Miniconda3-latest-Linux-x86_64.sh -b -p /home/nanograv/.local/miniconda && \
+    rm Miniconda3-latest-Linux-x86_64.sh
 
-ENV PATH="/home/nanograv/miniconda2/bin:/home/nanograv/bin:${PATH}"
+ENV PATH="/home/nanograv/.local/miniconda/bin:/home/nanograv/bin:${PATH}"
 
 # install basic Python packages
 RUN conda install -y numpy cython scipy && \
@@ -58,11 +58,7 @@ RUN conda install -y numpy cython scipy && \
 
 # install libstempo (before other Anaconda packages, esp. matplotlib, so there's no libgcc confusion)
 # get 2.3.3, specifically at 25 Aug 2017 (git sha 9cb7552); run git pull to update to latest
-RUN git clone https://github.com/vallis/libstempo.git && \
-    cd libstempo && \
-    git reset --hard 9cb7552 && \
-    python setup.py install --with-tempo2=/home/nanograv && \
-    cd /home/nanograv && ln -s source/libstempo/demo libstempo-demo
+RUN pip install --install-option="--with-tempo2=/home/nanograv/.local" git+https://github.com/vallis/libstempo@9cb7552
 
 # install more Python packages
 RUN conda install -y matplotlib ipython jupyter notebook h5py mpi4py numexpr statsmodels astropy ephem runipy && \
@@ -92,10 +88,6 @@ RUN pip install git+https://github.com/nanograv/enterprise@04607ef
 # matplotlib rc (default backend: Agg)
 RUN mkdir -p /home/nanograv/.config/matplotlib
 COPY matplotlibrc /home/nanograv/.config/matplotlib
-
-# now that everything is installed
-# set working directory to home
-WORKDIR /home/nanograv/
 
 # get NANOGrav 11yr data release
 RUN wget -q https://data.nanograv.org/static/data/NANOGrav_11y_20171023.tgz && \

--- a/docker/run_jupyter.sh
+++ b/docker/run_jupyter.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-cd ${1:-$HOME}
-/home/nanograv/.local/miniconda/bin/jupyter notebook --no-browser --port 8888 --ip=0.0.0.0

--- a/docker/run_jupyter.sh
+++ b/docker/run_jupyter.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 cd ${1:-$HOME}
-/home/nanograv/miniconda2/bin/jupyter notebook --no-browser --port 8888 --ip=0.0.0.0
+/home/nanograv/.local/miniconda/bin/jupyter notebook --no-browser --port 8888 --ip=0.0.0.0


### PR DESCRIPTION
Restructure the docker around Python3.  Move all things that the user doesn't need to change to `~/.local`.  Replace the usual `run_jupyter.sh` command with a default `CMD` call.  This will execute a jupyter notebook on `docker run`